### PR TITLE
update onLinkPress default function and documentation

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -18,7 +18,7 @@ var HTMLView = React.createClass({
 
   getDefaultProps() {
     return {
-      onLinkPress: Linking.openURL,
+      onLinkPress: url => Linking.openURL(url),
       onError: console.error.bind(console),
     }
   },

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ props:
 
 - `value`: a string of HTML content to render
 - `onLinkPress`: a function which will be called with a url when a link is pressed.
-  Passing this prop will override how links are handled (defaults to calling `LinkingIOS.openURL(url)`)
+  Passing this prop will override how links are handled (defaults to calling `Linking.openURL(url)`)
 - `stylesheet`: a stylesheet object keyed by tag name, which will override the 
   styles applied to those respective tags.
 - `renderNode`: a custom function to render HTML nodes however you see fit. If 


### PR DESCRIPTION
I had an issue using this component with the error `this._validateURL is not a function` from [Linking.js#170](https://github.com/facebook/react-native/blob/master/Libraries/Linking/Linking.js#L170). This fixes it. Also updated the doc to hint that this component works on Android too.