### PR TITLE
require from react instead of react-native

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,10 +1,11 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var htmlToElement = require('./htmlToElement')
 var {
   Linking,
   StyleSheet,
   Text,
-} = React
+} = ReactNative
 
 
 var HTMLView = React.createClass({

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Note: see the [troubleshooting](#troubleshooting) section below if you're having
 ### example
 
 ```js
-var React = require('react-native')
-var {Text, View, ListView} = React
+var React = require('react')
+var ReactNative = require('react-native')
+var {Text, View, ListView} = ReactNative
 
 var HTMLView = require('react-native-htmlview')
 
@@ -46,11 +47,12 @@ var styles = StyleSheet.create({
 })
 ```
 
-When a link is clicked, by default `React.Linking.openURL` is called with the 
+When a link is clicked, by default `ReactNative.Linking.openURL` is called with the 
 link url. You can customise what happens when a link is clicked with `onLinkPress`:
 
 ```js
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 
 var ContentView = React.createClass({
   render() {

--- a/__tests__/HTMLView-test.js
+++ b/__tests__/HTMLView-test.js
@@ -1,4 +1,5 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var TestUtils = require('react-addons-test-utils')
 var HTMLView = require('../HTMLView')
 jest.setMock('../htmlToElement', jest.fn())
@@ -26,6 +27,6 @@ describe('HTMLView', () => {
     shallowRenderer._instance._instance.componentDidMount()
 
     var second = shallowRenderer.getRenderOutput()
-    expect(second.props.children[0].type).toBe(React.Text)
+    expect(second.props.children[0].type).toBe(ReactNative.Text)
   })
 })

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -1,10 +1,11 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var htmlparser = require('./vendor/htmlparser2')
 var entities = require('./vendor/entities')
 
 var {
   Text,
-} = React
+} = ReactNative
 
 
 var LINE_BREAK = '\n'


### PR DESCRIPTION
In react-native 0.25 there will be a deprecation warning to use `React.createElement` instead of `ReactNative.createElement`, and to use the `react` package instead of `react-native` where possible, per [#7207](https://github.com/facebook/react-native/issues/7207) & [#7040](https://github.com/facebook/react-native/issues/7040).

![image](https://cloud.githubusercontent.com/assets/433409/14944035/d68eb1e0-0fe8-11e6-9e9b-88e84f5b9f45.png)