### PR TITLE
Headers should only have one single line break

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -42,7 +42,7 @@ function htmlToElement(rawHtml, opts, done) {
             {domToElement(node.children, node)}
             {node.name == 'br' || node.name == 'li' ? LINE_BREAK : null}
             {node.name == 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
-            {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? PARAGRAPH_BREAK : null}
+            {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? LINE_BREAK : null}
           </Text>
         )
       }


### PR DESCRIPTION
Currently headers have two break lines, this PR set only one break line to the h1, h2, h3, h4 and h5 tag.

