### PR TITLE
Converted HTMLView.js to ES6 syntax - Fixes issue in new React versions

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,79 +1,16 @@
-var React = require('react')
-var ReactNative = require('react-native')
-var htmlToElement = require('./htmlToElement')
-var {
+import React, { Component, PropTypes } from 'react';
+import htmlToElement from './htmlToElement';
+import {
   Linking,
   StyleSheet,
   Text,
-} = ReactNative
+} from 'react-native';
 
+const boldStyle = { fontWeight: '500' };
+const italicStyle = { fontStyle: 'italic' };
+const codeStyle = { fontFamily: 'Menlo' };
 
-var HTMLView = React.createClass({
-  propTypes: {
-    value: React.PropTypes.string,
-    stylesheet: React.PropTypes.object,
-    onLinkPress: React.PropTypes.func,
-    onError: React.PropTypes.func,
-    renderNode: React.PropTypes.func,
-  },
-
-  getDefaultProps() {
-    return {
-      onLinkPress: url => Linking.openURL(url),
-      onError: console.error.bind(console),
-    }
-  },
-
-  getInitialState() {
-    return {
-      element: null,
-    }
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.value !== nextProps.value) {
-      this.startHtmlRender(nextProps.value)
-    }
-  },
-
-  componentDidMount() {
-    this.mounted = true
-    this.startHtmlRender(this.props.value)
-  },
-
-  componentWillUnmount() {
-    this.mounted = false
-  },
-
-  startHtmlRender(value) {
-    if (!value) return this.setState({element: null})
-
-    var opts = {
-      linkHandler: this.props.onLinkPress,
-      styles: Object.assign({}, baseStyles, this.props.stylesheet),
-      customRenderer: this.props.renderNode,
-    }
-
-    htmlToElement(value, opts, (err, element) => {
-      if (err) return this.props.onError(err)
-
-      if (this.mounted) this.setState({element})
-    })
-  },
-
-  render() {
-    if (this.state.element) {
-      return <Text children={this.state.element} />
-    }
-    return <Text />
-  },
-})
-
-var boldStyle = {fontWeight: '500'}
-var italicStyle = {fontStyle: 'italic'}
-var codeStyle = {fontFamily: 'Menlo'}
-
-var baseStyles = StyleSheet.create({
+const baseStyles = StyleSheet.create({
   b: boldStyle,
   strong: boldStyle,
   i: italicStyle,
@@ -84,6 +21,72 @@ var baseStyles = StyleSheet.create({
     fontWeight: '500',
     color: '#007AFF',
   },
-})
+});
 
-module.exports = HTMLView
+class HtmlView extends Component {
+  constructor() {
+    super();
+    this.state = {
+      element: null,
+    };
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+    this.startHtmlRender(this.props.value);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.startHtmlRender(nextProps.value);
+    }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  startHtmlRender(value) {
+    if (!value) {
+      this.setState({ element: null });
+    }
+
+    const opts = {
+      linkHandler: this.props.onLinkPress,
+      styles: Object.assign({}, baseStyles, this.props.stylesheet),
+      customRenderer: this.props.renderNode,
+    };
+
+    htmlToElement(value, opts, (err, element) => {
+      if (err) {
+        this.props.onError(err);
+      }
+
+      if (this.mounted) {
+        this.setState({ element });
+      }
+    });
+  }
+
+  render() {
+    if (this.state.element) {
+      return <Text children={this.state.element} />;
+    }
+    return <Text />;
+  }
+}
+
+HtmlView.propTypes = {
+  value: PropTypes.string,
+  stylesheet: PropTypes.object,
+  onLinkPress: PropTypes.func,
+  onError: PropTypes.func,
+  renderNode: PropTypes.func,
+};
+
+HtmlView.defaultProps = {
+  onLinkPress: url => Linking.openURL(url),
+  onError: console.error.bind(console),
+};
+
+export default HtmlView;


### PR DESCRIPTION
Downloaded this module and started using it but got the following:
![Native module cannot be null](https://cloud.githubusercontent.com/assets/997157/16366014/7632023e-3bd5-11e6-9e67-0716132653ca.png)

It looks like this is due to the new es6 module import syntax introduced.  Changing syntax to this format fixed the issue.

For more info:
https://github.com/facebook/react-native/issues/8449