### PR TITLE
allow text-transformation like uppercase and lowercase

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -22,28 +22,38 @@ function htmlToElement(rawHtml, opts, done) {
         if (rendered || rendered === null) return rendered
       }
 
-      if (node.type == 'text') {
+      if (node.type === 'text') {
+        var data = node.data;
+        var textTransformation = opts.styles[parent.name] ? ReactNative.StyleSheet.flatten( opts.styles[parent.name] ).textTransformation : null;
+        switch(textTransformation) {
+          case 'uppercase':
+            data = data.toUpperCase();
+            break;
+          case 'lowercase':
+            data = data.toLowerCase();
+            break;
+        }
         return (
-          <Text key={index} style={parent ? opts.styles[parent.name] : null}>
-            {entities.decodeHTML(node.data)}
+            <Text key={index} style={parent ? opts.styles[parent.name] : null}>
+              {entities.decodeHTML(data)}
           </Text>
         )
       }
 
-      if (node.type == 'tag') {
+      if (node.type === 'tag') {
         var linkPressHandler = null
-        if (node.name == 'a' && node.attribs && node.attribs.href) {
+        if (node.name === 'a' && node.attribs && node.attribs.href) {
           linkPressHandler = () => opts.linkHandler(entities.decodeHTML(node.attribs.href))
         }
 
         return (
           <Text key={index} onPress={linkPressHandler}>
-            {node.name == 'pre' ? LINE_BREAK : null}
-            {node.name == 'li' ? BULLET : null}
+            {node.name === 'pre' ? LINE_BREAK : null}
+            {node.name === 'li' ? BULLET : null}
             {domToElement(node.children, node)}
-            {node.name == 'br' || node.name == 'li' ? LINE_BREAK : null}
-            {node.name == 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
-            {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? LINE_BREAK : null}
+            {node.name === 'br' || node.name === 'li' ? LINE_BREAK : null}
+            {node.name === 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
+            {node.name === 'h1' || node.name === 'h2' || node.name === 'h3' || node.name === 'h4' || node.name === 'h5' ? LINE_BREAK : null}
           </Text>
         )
       }


### PR DESCRIPTION
This Pull-request allows an **optional** new style-attribute called "textTransformation" to upper-case or lower-case the text of a tag like in CSS the attribute "text-transform" does.  

As in CSS, valid values are "lowercase" and "uppercase":

Example-Code of an stylesheet for htmlviewer:

```
 h: {
    ...baseStyle,
    fontFamily: 'SFUIText-Bold',
    textTransformation: 'uppercase',
  },

```
