### PR TITLE
Style inheritance support

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -70,7 +70,7 @@ class HtmlView extends Component {
 
   render() {
     if (this.state.element) {
-      return <Text children={this.state.element} />
+      return <Text style={this.props.stylesheet && this.props.stylesheet.rootStyles} children={this.state.element} />
     }
     return <Text />
   }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ var App = React.createClass({
 })
 
 var styles = StyleSheet.create({
+  rootStyles: {
+      fontSize: 15,
+      lineHeight: 20
+  },
   a: {
     fontWeight: '300',
     color: '#FF3366', // pink links

--- a/helper/Image.js
+++ b/helper/Image.js
@@ -1,8 +1,9 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var {
   Image,
   Dimensions,
-} = React
+} = ReactNative
 
 var {width} = Dimensions.get('window')
 

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -4,7 +4,7 @@ var htmlparser = require('./vendor/htmlparser2')
 var entities = require('./vendor/entities')
 
 var {
-  Text,
+    Text,
 } = ReactNative
 
 var Image = require('./helper/Image')
@@ -24,12 +24,11 @@ function htmlToElement(rawHtml, opts, done) {
         if (rendered || rendered === null) return rendered
       }
 
-
       if (node.type == 'text') {
         return (
-          <Text key={index} style={parent ? opts.styles[parent.name] : null}>
-            {entities.decodeHTML(node.data)}
-          </Text>
+            <Text key={index}>
+              {entities.decodeHTML(node.data)}
+            </Text>
         )
       }
 
@@ -48,7 +47,7 @@ function htmlToElement(rawHtml, opts, done) {
             height: img_h,
           }
           return (
-            <Image key={index} source={source} style={img_style} />
+              <Image key={index} source={source} style={img_style} />
           )
         }
 
@@ -58,14 +57,14 @@ function htmlToElement(rawHtml, opts, done) {
         }
 
         return (
-          <Text key={index} onPress={linkPressHandler}>
-            {node.name == 'pre' ? LINE_BREAK : null}
-            {node.name == 'li' ? BULLET : null}
-            {domToElement(node.children, node)}
-            {node.name == 'br' || node.name == 'li' ? LINE_BREAK : null}
-            {node.name == 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
-            {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? LINE_BREAK : null}
-          </Text>
+            <Text key={index} onPress={linkPressHandler} style={opts.styles[node.name]}>
+              {node.name == 'pre' ? LINE_BREAK : null}
+              {node.name == 'li' ? BULLET : null}
+              {domToElement(node.children, node)}
+              {node.name == 'br' || node.name == 'li' ? LINE_BREAK : null}
+              {node.name == 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
+              {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? LINE_BREAK : null}
+            </Text>
         )
       }
     })


### PR DESCRIPTION
I've added support for style inheritance of nested Text nodes (https://facebook.github.io/react-native/docs/text.html#nested-text) in two ways:
1. By moving the style property from the inner generated Text node to the Text node for the tag itself. This way tags inside other tags will inherit the styles.
2. By adding the "rootStyles" key option to the stylesheet, which is applied to the outer <Text> element. This allows for global style setting of the entire view.

This also fixes an issue on android, not being able to set the lineHeight. The lineHeight style only works on the outer Text node when nesting Text nodes, so you can now set the line height on the rootStyles property.
