### PR TITLE
Set style props on root text component. close #30

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -70,9 +70,9 @@ class HtmlView extends Component {
 
   render() {
     if (this.state.element) {
-      return <Text children={this.state.element} />
+      return <Text style={this.props.style} children={this.state.element} />
     }
-    return <Text />
+    return <Text style={this.props.style} />
   }
 }
 


### PR DESCRIPTION
For android it is in some situations necessary to be able to set styles on the root <Text> component, i.e. to set the line height.

Note: Not added to HtmlView.propTypes.propTypes yet.
