### PR TITLE
Underline style for u tags

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -8,6 +8,7 @@ import {
 
 const boldStyle = {fontWeight: '500'}
 const italicStyle = {fontStyle: 'italic'}
+const underlineStyle = {textDecorationLine: 'underline'}
 const codeStyle = {fontFamily: 'Menlo'}
 
 const baseStyles = StyleSheet.create({
@@ -15,6 +16,7 @@ const baseStyles = StyleSheet.create({
   strong: boldStyle,
   i: italicStyle,
   em: italicStyle,
+  u: underlineStyle,
   pre: codeStyle,
   code: codeStyle,
   a: {


### PR DESCRIPTION
This simply puts an underline for `<u>` tags that are commonly used on many WYSIWYG editors.
