### PR TITLE
Pass domToElement method to customRenderer.

### DIFF
--- a/helper/Image.js
+++ b/helper/Image.js
@@ -1,8 +1,9 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var {
   Image,
   Dimensions,
-} = React
+} = ReactNative
 
 var {width} = Dimensions.get('window')
 

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -20,7 +20,7 @@ function htmlToElement(rawHtml, opts, done) {
 
     return dom.map((node, index, list) => {
       if (opts.customRenderer) {
-        var rendered = opts.customRenderer(node, index, list)
+        var rendered = opts.customRenderer(node, index, list, domToElement)
         if (rendered || rendered === null) return rendered
       }
 


### PR DESCRIPTION
This passes the domToElement method to the renderNode method which is very useful when you want render a node in a custom way, but want to render all the children normally. My specific use case was for subtly adjusting the spacing between paragraphs, but it would be useful for many other use cases.

```js
//...
	renderNode(node, index, list, domToElement) {
		if (node.type === 'tag' && node.name === 'p' && index < list.length - 1) {
			return <Text key={index}>
				{domToElement(node.children, node)}
				{customParagraphBreak}
			</Text>;
		}
	}
//...
```