### PR TITLE
Add support to turn off line breaks

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -52,6 +52,7 @@ class HtmlView extends Component {
     }
 
     const opts = {
+      addLineBreaks: this.props.addLineBreaks,
       linkHandler: this.props.onLinkPress,
       styles: Object.assign({}, baseStyles, this.props.stylesheet),
       customRenderer: this.props.renderNode,
@@ -77,6 +78,7 @@ class HtmlView extends Component {
 }
 
 HtmlView.propTypes = {
+  addLineBreaks: PropTypes.bool,
   value: PropTypes.string,
   stylesheet: PropTypes.object,
   onLinkPress: PropTypes.func,
@@ -85,6 +87,7 @@ HtmlView.propTypes = {
 }
 
 HtmlView.defaultProps = {
+  addLineBreaks: true,
   onLinkPress: url => Linking.openURL(url),
   onError: console.error.bind(console),
 }

--- a/helper/Image.js
+++ b/helper/Image.js
@@ -1,8 +1,9 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var {
   Image,
   Dimensions,
-} = React
+} = ReactNative
 
 var {width} = Dimensions.get('window')
 

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -59,12 +59,12 @@ function htmlToElement(rawHtml, opts, done) {
 
         return (
           <Text key={index} onPress={linkPressHandler}>
-            {node.name == 'pre' ? LINE_BREAK : null}
+            {opts.addLineBreaks && node.name == 'pre' ? LINE_BREAK : null}
             {node.name == 'li' ? BULLET : null}
             {domToElement(node.children, node)}
-            {node.name == 'br' || node.name == 'li' ? LINE_BREAK : null}
-            {node.name == 'p' && index < list.length - 1 ? PARAGRAPH_BREAK : null}
-            {node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5' ? LINE_BREAK : null}
+            {opts.addLineBreaks && (node.name == 'br' || node.name == 'li') ? LINE_BREAK : null}
+            {opts.addLineBreaks && (node.name == 'p' && index < list.length - 1) ? PARAGRAPH_BREAK : null}
+            {opts.addLineBreaks && (node.name == 'h1' || node.name == 'h2' || node.name == 'h3' || node.name == 'h4' || node.name == 'h5') ? LINE_BREAK : null}
           </Text>
         )
       }


### PR DESCRIPTION
This PR adds a property - `addLineBreaks` - that allows turning off the placement of new line characters `\n` after the rendering of some elements.