### PR TITLE
Expose dom render

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -34,7 +34,7 @@ export default function htmlToElement(rawHtml, opts, done) {
 
     return dom.map((node, index, list) => {
       if (opts.customRenderer) {
-        const rendered = opts.customRenderer(node, index, list, parent);
+        const rendered = opts.customRenderer(node, index, list, parent, domToElement);
         if (rendered || rendered === null) return rendered;
       }
 


### PR DESCRIPTION
Make domToElement available to better support custom node rendering.

For example, when implementing a custom list (`ul`/`ol`), I want the content of the list items to be rendered just the same as all other content. By exposing `domToElement` I can now simply pass on the dom tree without having to implement the same logic in my application again.

**Edit** this now actually is a copy of #78, but up to date with master