### PR TITLE
Add singleParagraphBreak property

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -59,6 +59,7 @@ class HtmlView extends Component {
 
     const opts = {
       addLineBreaks: this.props.addLineBreaks,
+      singleParagraphBreak: this.props.singleParagraphBreak,
       linkHandler: this.props.onLinkPress,
       styles: Object.assign({}, baseStyles, this.props.stylesheet),
       customRenderer: this.props.renderNode,
@@ -91,10 +92,12 @@ HtmlView.propTypes = {
   onLinkPress: PropTypes.func,
   onError: PropTypes.func,
   renderNode: PropTypes.func,
+  singleParagraphBreak: PropTypes.bool
 };
 
 HtmlView.defaultProps = {
   addLineBreaks: true,
+  singleParagraphBreak: false,
   onLinkPress: url => Linking.openURL(url),
   onError: console.error.bind(console),
 };

--- a/HTMLView.js
+++ b/HTMLView.js
@@ -92,7 +92,7 @@ HtmlView.propTypes = {
   onLinkPress: PropTypes.func,
   onError: PropTypes.func,
   renderNode: PropTypes.func,
-  singleParagraphBreak: PropTypes.bool
+  singleParagraphBreak: PropTypes.bool,
 };
 
 HtmlView.defaultProps = {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ props:
   - `defaultRenderer` the default rendering implementation, so you can use the normal rendering logic for some subtree. `defaultRenderer` takes the following arguments:
     - `node` the node to render with the default rendering logic
     - `parent` the parent of node of `node`
+- `singleParagraphBreak`: changes the paragraph break from the defualt of two lines to one line.
 
 ### Example
 

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -68,7 +68,7 @@ export default function htmlToElement(rawHtml, opts, done) {
             break;
           case 'p':
             if (index < list.length - 1) {
-              linebreakAfter = PARAGRAPH_BREAK;
+              linebreakAfter = opts.singleParagraphBreak ? LINE_BREAK : PARAGRAPH_BREAK;
             }
             break;
           case 'br':


### PR DESCRIPTION
Adds a the property `singleParagraphBreak` that will set the line break after paragraphs to a single line instead of two.

Resolves #7 