### PR TITLE
Add defaultTextStyle Prop and some Tags supports 

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -9,8 +9,8 @@ import {
 const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
 const codeStyle = {fontFamily: 'Menlo'};
-const sStyle = {textDecorationLine: 'line-through'}
-const underlineStyle = {textDecorationLine: 'underline'}
+const sStyle = {textDecorationLine: 'line-through'};
+const underlineStyle = {textDecorationLine: 'underline'};
 
 const baseStyles = StyleSheet.create({
   b: boldStyle,
@@ -66,7 +66,7 @@ class HtmlView extends Component {
       linkHandler: this.props.onLinkPress,
       styles: Object.assign({}, baseStyles, this.props.stylesheet),
       customRenderer: this.props.renderNode,
-      defaultTextStyle: this.props.defaultTextStyle
+      defaultTextStyle: this.props.defaultTextStyle,
     };
 
     htmlToElement(value, opts, (err, element) => {

--- a/HTMLView.js
+++ b/HTMLView.js
@@ -10,6 +10,7 @@ const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
 const codeStyle = {fontFamily: 'Menlo'};
 const sStyle = {textDecorationLine: 'line-through'}
+const underlineStyle = {textDecorationLine: 'underline'}
 
 const baseStyles = StyleSheet.create({
   b: boldStyle,
@@ -18,6 +19,7 @@ const baseStyles = StyleSheet.create({
   em: italicStyle,
   pre: codeStyle,
   code: codeStyle,
+  u: underlineStyle,
   a: {
     fontWeight: '500',
     color: '#007AFF',
@@ -90,6 +92,7 @@ HtmlView.propTypes = {
   addLineBreaks: PropTypes.bool,
   value: PropTypes.string,
   stylesheet: PropTypes.object,
+  defaultTextStyle: PropTypes.object,
   style: View.propTypes.style,
   onLinkPress: PropTypes.func,
   onError: PropTypes.func,

--- a/HTMLView.js
+++ b/HTMLView.js
@@ -9,6 +9,7 @@ import {
 const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
 const codeStyle = {fontFamily: 'Menlo'};
+const sStyle = {textDecorationLine: 'line-through'}
 
 const baseStyles = StyleSheet.create({
   b: boldStyle,
@@ -21,6 +22,7 @@ const baseStyles = StyleSheet.create({
     fontWeight: '500',
     color: '#007AFF',
   },
+  s: sStyle,
   h1: {fontWeight: '500', fontSize: 36},
   h2: {fontWeight: '500', fontSize: 30},
   h3: {fontWeight: '500', fontSize: 24},
@@ -62,6 +64,7 @@ class HtmlView extends Component {
       linkHandler: this.props.onLinkPress,
       styles: Object.assign({}, baseStyles, this.props.stylesheet),
       customRenderer: this.props.renderNode,
+      defaultTextStyle: this.props.defaultTextStyle
     };
 
     htmlToElement(value, opts, (err, element) => {

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -41,7 +41,7 @@ export default function htmlToElement(rawHtml, opts, done) {
 
       if (node.type == 'text') {
         return (
-          <Text key={index} style={parent ? opts.styles[parent.name] : null}>
+          <Text key={index} style={[opts.defaultTextStyle, parent ? opts.styles[parent.name] : null]}>
             {entities.decodeHTML(node.data)}
           </Text>
         );
@@ -77,6 +77,7 @@ export default function htmlToElement(rawHtml, opts, done) {
           case 'h3':
           case 'h4':
           case 'h5':
+          case 'li':
             linebreakAfter = LINE_BREAK;
             break;
           }

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -41,7 +41,7 @@ export default function htmlToElement(rawHtml, opts, done) {
 
       if (node.type == 'text') {
         return (
-          <Text key={index} style={Object.assign({}, opts.defaultTextStyle, parent ? opts.styles[parent.name] : null )}>
+          <Text key={index} style={opts.defaultTextStyle ? Object.assign({}, opts.defaultTextStyle, parent ? opts.styles[parent.name] : null) : parent ? opts.styles[parent.name] : null}>
             {entities.decodeHTML(node.data)}
           </Text>
         );
@@ -77,7 +77,6 @@ export default function htmlToElement(rawHtml, opts, done) {
           case 'h3':
           case 'h4':
           case 'h5':
-          case 'li':
             linebreakAfter = LINE_BREAK;
             break;
           }

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -41,7 +41,7 @@ export default function htmlToElement(rawHtml, opts, done) {
 
       if (node.type == 'text') {
         return (
-          <Text key={index} style={[opts.defaultTextStyle, parent ? opts.styles[parent.name] : null]}>
+          <Text key={index} style={Object.assign({}, opts.defaultTextStyle, parent ? opts.styles[parent.name] : null )}>
             {entities.decodeHTML(node.data)}
           </Text>
         );


### PR DESCRIPTION
I notice that there is no easy way to edit all the texts at once when I needed to add a specific fontFamily to all text.
- I added the prop defaultTextStyle that support all [text styles](https://facebook.github.io/react-native/docs/text.html#style).
- In addition, now HTMLView support **u**(underline) and **s**(scratch) tags.
- **li** tag now end with a LineBreak

Solve Issues:
[#70](https://github.com/jsdf/react-native-htmlview/issues/70)
