### PR TITLE
Bug fix: If LI had no parent element, the parent would be undefined. …

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -84,9 +84,9 @@ export default function htmlToElement(rawHtml, opts, done) {
 
         let listItemPrefix = null;
         if (node.name == 'li') {
-        	if(!parent) {
-        		listItemPrefix = BULLET;
-        	} else if (parent.name == 'ol') {
+          if (!parent) {
+            listItemPrefix = BULLET;
+          } else if (parent.name == 'ol') {
             listItemPrefix = `${index + 1}. `;
           } else if (parent.name == 'ul') {
             listItemPrefix = BULLET;

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -84,7 +84,9 @@ export default function htmlToElement(rawHtml, opts, done) {
 
         let listItemPrefix = null;
         if (node.name == 'li') {
-          if (parent.name == 'ol') {
+        	if(!parent) {
+        		listItemPrefix = BULLET;
+        	} else if (parent.name == 'ol') {
             listItemPrefix = `${index + 1}. `;
           } else if (parent.name == 'ul') {
             listItemPrefix = BULLET;


### PR DESCRIPTION
…Fix: If parent UL/OL does not exist, default listItemPrefix to BULLET.