### PR TITLE
Add style rendering improvements

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -5,6 +5,7 @@ import {Linking, StyleSheet, View} from 'react-native';
 
 const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
+const underlineStyle = {textDecorationLine: 'underline'}
 const codeStyle = {fontFamily: 'Menlo'};
 
 const baseStyles = StyleSheet.create({
@@ -12,6 +13,7 @@ const baseStyles = StyleSheet.create({
   strong: boldStyle,
   i: italicStyle,
   em: italicStyle,
+  u: underlineStyle,
   pre: codeStyle,
   code: codeStyle,
   a: {

--- a/HTMLView.js
+++ b/HTMLView.js
@@ -5,7 +5,7 @@ import {Linking, StyleSheet, View} from 'react-native';
 
 const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
-const underlineStyle = {textDecorationLine: 'underline'}
+const underlineStyle = {textDecorationLine: 'underline'};
 const codeStyle = {fontFamily: 'Menlo'};
 
 const baseStyles = StyleSheet.create({

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -24,7 +24,11 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
               
@@ -40,7 +44,12 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
               
@@ -50,7 +59,11 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
           
@@ -82,7 +95,11 @@ exports[`<HTMLView/> can use a custom renderer 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
               
@@ -129,7 +146,11 @@ exports[`<HTMLView/> can use custom node props 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
               
@@ -145,7 +166,12 @@ exports[`<HTMLView/> can use custom node props 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
               
@@ -155,7 +181,11 @@ exports[`<HTMLView/> can use custom node props 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
           
@@ -187,7 +217,11 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
                 
@@ -203,10 +237,13 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         allowFontScaling={true}
         ellipsizeMode="tail"
         style={
-          Object {
-            "fontSize": 30,
-            "fontWeight": "500",
-          }
+          Array [
+            Object {
+              "fontSize": 30,
+              "fontWeight": "500",
+            },
+            Object {},
+          ]
         }
       >
         Dwayne’s only companion at night was a Labrador retriever named Sparky.
@@ -216,7 +253,11 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
               
@@ -231,7 +272,12 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
                 Sparky could not wag his tail-because of an automobile accident many years ago, so he had no way of telling other dogs how friendly he was.
@@ -246,7 +292,12 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
                 He opened the door of the cage, something Bill couldn’t have done in a thousand years. Bill flew over to a windowsill.
@@ -257,7 +308,11 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
             
@@ -342,10 +397,13 @@ exports[`<HTMLView/> should render an empty <Text/> element 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         style={
-          Object {
-            "color": "#007AFF",
-            "fontWeight": "500",
-          }
+          Array [
+            Object {
+              "color": "#007AFF",
+              "fontWeight": "500",
+            },
+            Object {},
+          ]
         }
       >
         &hearts nice job!
@@ -376,10 +434,17 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
          a 
       </Text>
+      
+      
     </Text>
     <Text
       accessible={true}
@@ -392,10 +457,17 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
          b 
       </Text>
+      
+      
     </Text>
   </Text>
 </View>
@@ -424,7 +496,11 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
               
@@ -439,7 +515,12 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
                   
@@ -455,10 +536,14 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           allowFontScaling={true}
           ellipsizeMode="tail"
           style={
-            Object {
-              "fontSize": 30,
-              "fontWeight": "500",
-            }
+            Array [
+              Object {
+                "fontSize": 30,
+                "fontWeight": "500",
+              },
+              Object {},
+              Object {},
+            ]
           }
         >
           &gt; Dwayne’s only companion at night was a Labrador retriever named Sparky.
@@ -470,7 +555,12 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
                 
@@ -485,7 +575,13 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}
+          style={
+            Array [
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
         >
           
                   
@@ -501,9 +597,14 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             allowFontScaling={true}
             ellipsizeMode="tail"
             style={
-              Object {
-                "fontStyle": "italic",
-              }
+              Array [
+                Object {
+                  "fontStyle": "italic",
+                },
+                Object {},
+                Object {},
+                Object {},
+              ]
             }
           >
             Sparky could not wag his tail-because of an automobile accident many years ago, so he had no way of telling other dogs how friendly he was.
@@ -521,9 +622,17 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontWeight": "500",
+                  },
+                  Object {
+                    "fontStyle": "italic",
+                  },
+                  Object {},
+                  Object {},
+                  Object {},
+                ]
               }
             >
               The undippable flag was a beauty, and the anthem and the vacant motto might not have mattered much, if it weren’t for this: a lot of citizens were so ignored and cheated and insulted that they thought they might be in the wrong country, or even on the wrong planet, that some terrible mistake had been made.
@@ -539,7 +648,12 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
                 
@@ -554,7 +668,13 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}
+          style={
+            Array [
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
         >
           
                     [1] 
@@ -570,10 +690,15 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             allowFontScaling={true}
             ellipsizeMode="tail"
             style={
-              Object {
-                "color": "#007AFF",
-                "fontWeight": "500",
-              }
+              Array [
+                Object {
+                  "color": "#007AFF",
+                  "fontWeight": "500",
+                },
+                Object {},
+                Object {},
+                Object {},
+              ]
             }
           >
             https://code.facebook.com/posts/1505962329687926/flow-a-new-...
@@ -583,7 +708,13 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}
+          style={
+            Array [
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
         >
           
                   
@@ -596,7 +727,12 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
         
               
@@ -606,7 +742,11 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={undefined}
+      style={
+        Array [
+          Object {},
+        ]
+      }
     >
       
           
@@ -660,10 +800,17 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
          a 
       </Text>
+      
+      
     </Text>
     <Text
       accessible={true}
@@ -676,10 +823,17 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={undefined}
+        style={
+          Array [
+            Object {},
+            Object {},
+          ]
+        }
       >
          b 
       </Text>
+      
+      
     </Text>
   </Text>
 </View>

--- a/example/__tests__/__snapshots__/Example-test.js.snap
+++ b/example/__tests__/__snapshots__/Example-test.js.snap
@@ -32,7 +32,11 @@ exports[`<Example/> should render 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}
+          style={
+            Array [
+              Object {},
+            ]
+          }
         >
           
               
@@ -47,7 +51,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                   
@@ -69,9 +78,16 @@ exports[`<Example/> should render 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
+                  Array [
+                    Object {
+                      "fontStyle": "italic",
+                    },
+                    Object {
+                      "fontWeight": "500",
+                    },
+                    Object {},
+                    Object {},
+                  ]
                 }
               >
                 &gt; Dwayne’s only companion at night was a Labrador retriever named Sparky.
@@ -82,7 +98,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -97,7 +118,13 @@ exports[`<Example/> should render 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              style={undefined}
+              style={
+                Array [
+                  Object {},
+                  Object {},
+                  Object {},
+                ]
+              }
             >
               
                   
@@ -113,9 +140,14 @@ exports[`<Example/> should render 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
+                  Array [
+                    Object {
+                      "fontStyle": "italic",
+                    },
+                    Object {},
+                    Object {},
+                    Object {},
+                  ]
                 }
               >
                 Sparky could not wag his tail-because of an automobile accident many years ago, so he had no way of telling other dogs how friendly he was.
@@ -133,9 +165,17 @@ exports[`<Example/> should render 1`] = `
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                   style={
-                    Object {
-                      "fontWeight": "500",
-                    }
+                    Array [
+                      Object {
+                        "fontWeight": "500",
+                      },
+                      Object {
+                        "fontStyle": "italic",
+                      },
+                      Object {},
+                      Object {},
+                      Object {},
+                    ]
                   }
                 >
                   The undippable flag was a beauty, and the anthem and the vacant motto might not have mattered much, if it weren’t for this: a lot of citizens were so ignored and cheated and insulted that they thought they might be in the wrong country, or even on the wrong planet, that some terrible mistake had been made.
@@ -151,7 +191,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -166,7 +211,13 @@ exports[`<Example/> should render 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              style={undefined}
+              style={
+                Array [
+                  Object {},
+                  Object {},
+                  Object {},
+                ]
+              }
             >
               
                     [1] 
@@ -182,10 +233,15 @@ exports[`<Example/> should render 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 style={
-                  Object {
-                    "color": "#007AFF",
-                    "fontWeight": "500",
-                  }
+                  Array [
+                    Object {
+                      "color": "#007AFF",
+                      "fontWeight": "500",
+                    },
+                    Object {},
+                    Object {},
+                    Object {},
+                  ]
                 }
               >
                 https://code.facebook.com/posts/1505962329687926/flow-a-new-...
@@ -195,7 +251,13 @@ exports[`<Example/> should render 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
-              style={undefined}
+              style={
+                Array [
+                  Object {},
+                  Object {},
+                  Object {},
+                ]
+              }
             >
               
                   
@@ -208,7 +270,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -233,7 +300,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
             
@@ -250,10 +322,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 36,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 36,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -265,7 +341,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -281,10 +362,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 30,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 30,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -296,7 +381,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -312,10 +402,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 24,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 24,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -327,7 +421,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -343,10 +442,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 18,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 18,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -358,7 +461,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -374,10 +482,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -389,7 +501,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 
@@ -405,10 +522,14 @@ exports[`<Example/> should render 1`] = `
               allowFontScaling={true}
               ellipsizeMode="tail"
               style={
-                Object {
-                  "fontSize": 12,
-                  "fontWeight": "500",
-                }
+                Array [
+                  Object {
+                    "fontSize": 12,
+                    "fontWeight": "500",
+                  },
+                  Object {},
+                  Object {},
+                ]
               }
             >
               Dwayne’s only companion at night
@@ -418,7 +539,12 @@ exports[`<Example/> should render 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            style={undefined}
+            style={
+              Array [
+                Object {},
+                Object {},
+              ]
+            }
           >
             
                 ayyy
@@ -446,7 +572,11 @@ exports[`<Example/> should render 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={undefined}
+          style={
+            Array [
+              Object {},
+            ]
+          }
         >
           
           

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -41,6 +41,12 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
     ...customOpts,
   };
 
+  function inheritedStyle(parent) {
+    if (!parent) { return null; }
+    const style = [opts.styles[parent.name] || {}];
+    return parent.parent ? style.concat(inheritedStyle(parent.parent)) : style;
+  }
+
   function domToElement(dom, parent) {
     if (!dom) return null;
 
@@ -65,7 +71,7 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
           <TextComponent
             {...opts.textComponentProps}
             key={index}
-            style={parent ? opts.styles[parent.name] : null}
+            style={inheritedStyle(parent)}
           >
             {entities.decodeHTML(node.data)}
           </TextComponent>

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -113,6 +113,7 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
           } else if (parent.name == 'ul') {
             listItemPrefix = opts.bullet;
           }
+          linebreakAfter = opts.lineBreak;
         }
 
         const {NodeComponent} = opts;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-react": "4.3.0",
     "jest": "^19.0.2",
     "prettier": "^1.5.2",
-    "prop-types": "^15.5.7",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,7 +3364,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION

![yup](https://user-images.githubusercontent.com/4611628/28022812-7d09d000-658c-11e7-8b25-f3d39a7743c6.gif)

These are some style rendering fixes I was using on my own fork.

Based on 
- #4 by @michalraska
- #37 by @tywhang

Also adds line break after li elements.