### PR TITLE
Apply default and custom styles to list item prefix

### DIFF
--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -501,7 +501,21 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
       ellipsizeMode="tail"
       onPress={null}
     >
-      1. 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        1. 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -527,7 +541,21 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
       ellipsizeMode="tail"
       onPress={null}
     >
-      2. 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        1. 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -927,7 +955,21 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
       ellipsizeMode="tail"
       onPress={null}
     >
-      • 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        • 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -953,7 +995,21 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
       ellipsizeMode="tail"
       onPress={null}
     >
-      • 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        • 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -554,7 +554,7 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
           ]
         }
       >
-        1. 
+        2. 
       </Text>
       <Text
         accessible={true}

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -274,7 +274,21 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
       onLongPress={null}
       onPress={null}
     >
-      1. 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        1. 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -317,7 +331,21 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
       onLongPress={null}
       onPress={null}
     >
-      2. 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+      >
+        2. 
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -118,10 +118,17 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
 
         let listItemPrefix = null;
         if (node.name === 'li') {
+          const defaultStyle = opts.textComponentProps ? opts.textComponentProps.style : null;
+          const customStyle = inheritedStyle(parent);
+
           if (parent.name === 'ol') {
-            listItemPrefix = `${index + 1}. `;
+            listItemPrefix = (<TextComponent style={[defaultStyle, customStyle]}>
+              {`${index + 1}. `}
+            </TextComponent>);
           } else if (parent.name === 'ul') {
-            listItemPrefix = opts.bullet;
+            listItemPrefix = (<TextComponent style={[defaultStyle, customStyle]}>
+              {opts.bullet}
+            </TextComponent>);
           }
           linebreakAfter = opts.lineBreak;
         }


### PR DESCRIPTION
![thisisfine](https://user-images.githubusercontent.com/4611628/28372333-b530ffac-6c9f-11e7-8698-4a994a876096.gif)

Styling (both default and custom) was not applied to the list items prefixes (bullets / numbering). 

### Example

``` js
<HTMLView
  value={HTML}
  textComponentProps={{ style: { color: '#ffffff' } }}
/>
```

### Before
![screen shot 2017-07-19 at 16 17 44](https://user-images.githubusercontent.com/4611628/28371865-68ea23e0-6c9e-11e7-89c8-0a11c920025f.png)

### After
![screen shot 2017-07-19 at 16 24 02](https://user-images.githubusercontent.com/4611628/28371959-bba60a36-6c9e-11e7-956f-b4713a6dfbd9.png)

