### PR TITLE
Fix order of cascading style inheritance

### DIFF
--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -32,10 +32,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -56,11 +53,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -75,10 +68,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -120,10 +110,7 @@ exports[`<HTMLView/> can use a custom renderer 1`] = `
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -185,10 +172,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -209,11 +193,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -228,10 +208,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -273,10 +250,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -296,14 +270,10 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {
-                "fontSize": 30,
-                "fontWeight": "500",
-              },
-            ],
+            Object {
+              "fontSize": 30,
+              "fontWeight": "500",
+            },
           ]
         }
       >
@@ -317,10 +287,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -340,11 +307,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -364,11 +327,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -384,10 +343,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -481,14 +437,10 @@ exports[`<HTMLView/> should render an empty <Text/> element 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {
-                "color": "#007AFF",
-                "fontWeight": "500",
-              },
-            ],
+            Object {
+              "color": "#007AFF",
+              "fontWeight": "500",
+            },
           ]
         }
       >
@@ -523,11 +475,7 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -550,11 +498,7 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -598,10 +542,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -621,11 +562,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -645,15 +582,10 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-                Object {},
-                Object {
-                  "fontSize": 30,
-                  "fontWeight": "500",
-                },
-              ],
+              Object {
+                "fontSize": 30,
+                "fontWeight": "500",
+              },
             ]
           }
         >
@@ -669,11 +601,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -693,12 +621,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-                Object {},
-                Object {},
-              ],
+              Object {},
             ]
           }
         >
@@ -718,15 +641,9 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                  Object {},
-                  Object {
-                    "fontStyle": "italic",
-                  },
-                ],
+                Object {
+                  "fontStyle": "italic",
+                },
               ]
             }
           >
@@ -747,18 +664,10 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontStyle": "italic",
-                    },
-                    Object {
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontStyle": "italic",
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -778,11 +687,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -802,12 +707,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-                Object {},
-                Object {},
-              ],
+              Object {},
             ]
           }
         >
@@ -827,16 +727,10 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                  Object {},
-                  Object {
-                    "color": "#007AFF",
-                    "fontWeight": "500",
-                  },
-                ],
+                Object {
+                  "color": "#007AFF",
+                  "fontWeight": "500",
+                },
               ]
             }
           >
@@ -850,12 +744,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-                Object {},
-                Object {},
-              ],
+              Object {},
             ]
           }
         >
@@ -873,11 +762,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -892,10 +777,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
       style={
         Array [
           null,
-          Array [
-            Object {},
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -964,11 +846,7 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -991,11 +869,7 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -242,9 +242,7 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
       style={
         Array [
           null,
-          Array [
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -266,10 +264,7 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -285,9 +280,7 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
       style={
         Array [
           null,
-          Array [
-            Object {},
-          ],
+          Object {},
         ]
       }
     >
@@ -309,10 +302,7 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
         style={
           Array [
             null,
-            Array [
-              Object {},
-              Object {},
-            ],
+            Object {},
           ]
         }
       >
@@ -328,9 +318,7 @@ exports[`<HTMLView/> should handle additional text nodes between list items 1`] 
       style={
         Array [
           null,
-          Array [
-            Object {},
-          ],
+          Object {},
         ]
       }
     >

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -34,6 +34,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
           null,
           Array [
             Object {},
+            Object {},
           ],
         ]
       }
@@ -58,6 +59,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -74,6 +76,7 @@ exports[`<HTMLView/> can use a custom node class 1`] = `
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -118,6 +121,7 @@ exports[`<HTMLView/> can use a custom renderer 1`] = `
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -183,6 +187,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
           null,
           Array [
             Object {},
+            Object {},
           ],
         ]
       }
@@ -207,6 +212,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -223,6 +229,7 @@ exports[`<HTMLView/> can use custom node props 1`] = `
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -268,6 +275,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
           null,
           Array [
             Object {},
+            Object {},
           ],
         ]
       }
@@ -289,11 +297,12 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
           Array [
             null,
             Array [
+              Object {},
+              Object {},
               Object {
                 "fontSize": 30,
                 "fontWeight": "500",
               },
-              Object {},
             ],
           ]
         }
@@ -309,6 +318,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -331,6 +341,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
           Array [
             null,
             Array [
+              Object {},
               Object {},
               Object {},
             ],
@@ -356,6 +367,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -373,6 +385,7 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -469,11 +482,12 @@ exports[`<HTMLView/> should render an empty <Text/> element 1`] = `
           Array [
             null,
             Array [
+              Object {},
+              Object {},
               Object {
                 "color": "#007AFF",
                 "fontWeight": "500",
               },
-              Object {},
             ],
           ]
         }
@@ -512,6 +526,7 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -536,6 +551,7 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
           Array [
             null,
             Array [
+              Object {},
               Object {},
               Object {},
             ],
@@ -584,6 +600,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           null,
           Array [
             Object {},
+            Object {},
           ],
         ]
       }
@@ -607,6 +624,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -628,12 +646,13 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             Array [
               null,
               Array [
+                Object {},
+                Object {},
+                Object {},
                 Object {
                   "fontSize": 30,
                   "fontWeight": "500",
                 },
-                Object {},
-                Object {},
               ],
             ]
           }
@@ -651,6 +670,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           Array [
             null,
             Array [
+              Object {},
               Object {},
               Object {},
             ],
@@ -674,6 +694,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             Array [
               null,
               Array [
+                Object {},
                 Object {},
                 Object {},
                 Object {},
@@ -698,12 +719,13 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
               Array [
                 null,
                 Array [
+                  Object {},
+                  Object {},
+                  Object {},
+                  Object {},
                   Object {
                     "fontStyle": "italic",
                   },
-                  Object {},
-                  Object {},
-                  Object {},
                 ],
               ]
             }
@@ -726,15 +748,16 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
                 Array [
                   null,
                   Array [
-                    Object {
-                      "fontWeight": "500",
-                    },
+                    Object {},
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontStyle": "italic",
                     },
-                    Object {},
-                    Object {},
-                    Object {},
+                    Object {
+                      "fontWeight": "500",
+                    },
                   ],
                 ]
               }
@@ -756,6 +779,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
           Array [
             null,
             Array [
+              Object {},
               Object {},
               Object {},
             ],
@@ -782,6 +806,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
                 Object {},
                 Object {},
                 Object {},
+                Object {},
               ],
             ]
           }
@@ -803,13 +828,14 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
               Array [
                 null,
                 Array [
+                  Object {},
+                  Object {},
+                  Object {},
+                  Object {},
                   Object {
                     "color": "#007AFF",
                     "fontWeight": "500",
                   },
-                  Object {},
-                  Object {},
-                  Object {},
                 ],
               ]
             }
@@ -825,6 +851,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             Array [
               null,
               Array [
+                Object {},
                 Object {},
                 Object {},
                 Object {},
@@ -849,6 +876,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -865,6 +893,7 @@ exports[`<HTMLView/> should render shoddy html including headings, links, bold, 
         Array [
           null,
           Array [
+            Object {},
             Object {},
           ],
         ]
@@ -938,6 +967,7 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
             Array [
               Object {},
               Object {},
+              Object {},
             ],
           ]
         }
@@ -962,6 +992,7 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
           Array [
             null,
             Array [
+              Object {},
               Object {},
               Object {},
             ],

--- a/example/__tests__/__snapshots__/Example-test.js.snap
+++ b/example/__tests__/__snapshots__/Example-test.js.snap
@@ -40,10 +40,7 @@ exports[`<Example/> should render 1`] = `
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-              ],
+              Object {},
             ]
           }
         >
@@ -63,11 +60,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -93,17 +86,10 @@ exports[`<Example/> should render 1`] = `
                 style={
                   Array [
                     null,
-                    Array [
-                      Object {},
-                      Object {},
-                      Object {},
-                      Object {
-                        "fontWeight": "500",
-                      },
-                      Object {
-                        "fontStyle": "italic",
-                      },
-                    ],
+                    Object {
+                      "fontStyle": "italic",
+                      "fontWeight": "500",
+                    },
                   ]
                 }
               >
@@ -118,11 +104,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -142,12 +124,7 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {},
-                  ],
+                  Object {},
                 ]
               }
             >
@@ -167,15 +144,9 @@ exports[`<Example/> should render 1`] = `
                 style={
                   Array [
                     null,
-                    Array [
-                      Object {},
-                      Object {},
-                      Object {},
-                      Object {},
-                      Object {
-                        "fontStyle": "italic",
-                      },
-                    ],
+                    Object {
+                      "fontStyle": "italic",
+                    },
                   ]
                 }
               >
@@ -196,18 +167,10 @@ exports[`<Example/> should render 1`] = `
                   style={
                     Array [
                       null,
-                      Array [
-                        Object {},
-                        Object {},
-                        Object {},
-                        Object {},
-                        Object {
-                          "fontStyle": "italic",
-                        },
-                        Object {
-                          "fontWeight": "500",
-                        },
-                      ],
+                      Object {
+                        "fontStyle": "italic",
+                        "fontWeight": "500",
+                      },
                     ]
                   }
                 >
@@ -227,11 +190,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -251,12 +210,7 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {},
-                  ],
+                  Object {},
                 ]
               }
             >
@@ -276,16 +230,10 @@ exports[`<Example/> should render 1`] = `
                 style={
                   Array [
                     null,
-                    Array [
-                      Object {},
-                      Object {},
-                      Object {},
-                      Object {},
-                      Object {
-                        "color": "#007AFF",
-                        "fontWeight": "500",
-                      },
-                    ],
+                    Object {
+                      "color": "#007AFF",
+                      "fontWeight": "500",
+                    },
                   ]
                 }
               >
@@ -299,12 +247,7 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {},
-                  ],
+                  Object {},
                 ]
               }
             >
@@ -322,11 +265,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -356,11 +295,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -381,15 +316,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 36,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 36,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -405,11 +335,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -429,15 +355,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 30,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 30,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -453,11 +374,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -477,15 +394,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 24,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 24,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -501,11 +413,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -525,15 +433,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 18,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 18,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -549,11 +452,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -573,15 +472,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 14,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -597,11 +491,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -621,15 +511,10 @@ exports[`<Example/> should render 1`] = `
               style={
                 Array [
                   null,
-                  Array [
-                    Object {},
-                    Object {},
-                    Object {},
-                    Object {
-                      "fontSize": 12,
-                      "fontWeight": "500",
-                    },
-                  ],
+                  Object {
+                    "fontSize": 12,
+                    "fontWeight": "500",
+                  },
                 ]
               }
             >
@@ -643,11 +528,7 @@ exports[`<Example/> should render 1`] = `
             style={
               Array [
                 null,
-                Array [
-                  Object {},
-                  Object {},
-                  Object {},
-                ],
+                Object {},
               ]
             }
           >
@@ -680,10 +561,7 @@ exports[`<Example/> should render 1`] = `
           style={
             Array [
               null,
-              Array [
-                Object {},
-                Object {},
-              ],
+              Object {},
             ]
           }
         >

--- a/example/__tests__/__snapshots__/Example-test.js.snap
+++ b/example/__tests__/__snapshots__/Example-test.js.snap
@@ -42,6 +42,7 @@ exports[`<Example/> should render 1`] = `
               null,
               Array [
                 Object {},
+                Object {},
               ],
             ]
           }
@@ -63,6 +64,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -92,14 +94,15 @@ exports[`<Example/> should render 1`] = `
                   Array [
                     null,
                     Array [
-                      Object {
-                        "fontStyle": "italic",
-                      },
+                      Object {},
+                      Object {},
+                      Object {},
                       Object {
                         "fontWeight": "500",
                       },
-                      Object {},
-                      Object {},
+                      Object {
+                        "fontStyle": "italic",
+                      },
                     ],
                   ]
                 }
@@ -116,6 +119,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -139,6 +143,7 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
                     Object {},
                     Object {},
                     Object {},
@@ -163,12 +168,13 @@ exports[`<Example/> should render 1`] = `
                   Array [
                     null,
                     Array [
+                      Object {},
+                      Object {},
+                      Object {},
+                      Object {},
                       Object {
                         "fontStyle": "italic",
                       },
-                      Object {},
-                      Object {},
-                      Object {},
                     ],
                   ]
                 }
@@ -191,15 +197,16 @@ exports[`<Example/> should render 1`] = `
                     Array [
                       null,
                       Array [
-                        Object {
-                          "fontWeight": "500",
-                        },
+                        Object {},
+                        Object {},
+                        Object {},
+                        Object {},
                         Object {
                           "fontStyle": "italic",
                         },
-                        Object {},
-                        Object {},
-                        Object {},
+                        Object {
+                          "fontWeight": "500",
+                        },
                       ],
                     ]
                   }
@@ -223,6 +230,7 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   Object {},
                   Object {},
+                  Object {},
                 ],
               ]
             }
@@ -244,6 +252,7 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
                     Object {},
                     Object {},
                     Object {},
@@ -268,13 +277,14 @@ exports[`<Example/> should render 1`] = `
                   Array [
                     null,
                     Array [
+                      Object {},
+                      Object {},
+                      Object {},
+                      Object {},
                       Object {
                         "color": "#007AFF",
                         "fontWeight": "500",
                       },
-                      Object {},
-                      Object {},
-                      Object {},
                     ],
                   ]
                 }
@@ -290,6 +300,7 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
                     Object {},
                     Object {},
                     Object {},
@@ -312,6 +323,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -347,6 +359,7 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   Object {},
                   Object {},
+                  Object {},
                 ],
               ]
             }
@@ -369,12 +382,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 36,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -392,6 +406,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -415,12 +430,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 30,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -438,6 +454,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -461,12 +478,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 24,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -484,6 +502,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -507,12 +526,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 18,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -530,6 +550,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -553,12 +574,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 14,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -576,6 +598,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -599,12 +622,13 @@ exports[`<Example/> should render 1`] = `
                 Array [
                   null,
                   Array [
+                    Object {},
+                    Object {},
+                    Object {},
                     Object {
                       "fontSize": 12,
                       "fontWeight": "500",
                     },
-                    Object {},
-                    Object {},
                   ],
                 ]
               }
@@ -620,6 +644,7 @@ exports[`<Example/> should render 1`] = `
               Array [
                 null,
                 Array [
+                  Object {},
                   Object {},
                   Object {},
                 ],
@@ -656,6 +681,7 @@ exports[`<Example/> should render 1`] = `
             Array [
               null,
               Array [
+                Object {},
                 Object {},
               ],
             ]

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -43,9 +43,10 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
   };
 
   function inheritedStyle(parent) {
-    if (!parent) { return null; }
+    if (!parent) return null;
     const style = [opts.styles[parent.name] || {}];
-    return parent.parent ? style.concat(inheritedStyle(parent.parent)) : style;
+    const parentStyle = inheritedStyle(parent.parent) || [{}];
+    return parentStyle.concat(style);
   }
 
   function domToElement(dom, parent) {

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -44,9 +44,9 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
 
   function inheritedStyle(parent) {
     if (!parent) return null;
-    const style = [opts.styles[parent.name] || {}];
-    const parentStyle = inheritedStyle(parent.parent) || [{}];
-    return parentStyle.concat(style);
+    const style = opts.styles[parent.name] || {};
+    const parentStyle = inheritedStyle(parent.parent) || {};
+    return {...parentStyle, ...style};
   }
 
   function domToElement(dom, parent) {


### PR DESCRIPTION
![gettingsomewhere](https://user-images.githubusercontent.com/4611628/28376525-9c7309be-6caa-11e7-8fdf-d1d4fe3490ec.gif)

Style inheritance was added in #125, but the order of applying them is reversed from the expected cascading result:

``` js
<HTMLView
  value="<b>RED<u>GREEN<i>BLUE</i></u></b>"
  stylesheet={{
    b: { color: 'red' },
    u: { color: 'green' },
    i: { color: 'blue' },
  }}
/>
```

![screen shot 2017-07-19 at 17 46 52](https://user-images.githubusercontent.com/4611628/28376676-0600ffa8-6cab-11e7-80d1-3d5e604a7663.png)

This fix will add the parent styles *before* the child styles, fixing cascading inheritance as expected:

![screen shot 2017-07-19 at 17 46 24](https://user-images.githubusercontent.com/4611628/28376755-3986d71c-6cab-11e7-810f-1d5d6a13eeec.png)
