### PR TITLE
Fixed blurred images if not provided width, height

### DIFF
--- a/AutoSizedImage.js
+++ b/AutoSizedImage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
 import {
   Image,
   Dimensions,
@@ -10,7 +10,7 @@ const baseStyle = {
   backgroundColor: 'transparent',
 };
 
-export default class AutoSizedImage extends React.Component {
+export default class AutoSizedImage extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/AutoSizedImage.js
+++ b/AutoSizedImage.js
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React from 'react';
 import {
   Image,
   Dimensions,
@@ -10,23 +10,23 @@ const baseStyle = {
   backgroundColor: 'transparent',
 };
 
-export default class AutoSizedImage extends PureComponent {
+export default class AutoSizedImage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      // set width 1 is for preventing the warning
+      // set width 0 is for preventing mipmapping in iOS
       // You must specify a width and height for the image %s
-      width: this.props.style.width || 1,
-      height: this.props.style.height || 1,
+      width: this.props.style.width || 0,
+      height: this.props.style.height || 0,
     };
   }
 
-  componentDidMount() {
+  async componentWillMount() {
     //avoid repaint if width/height is given
-    if (this.props.style.width || this.props.style.height) {
+    if (this.props.style.width && this.props.style.height) {
       return;
     }
-    Image.getSize(this.props.source.uri, (w, h) => {
+    await Image.getSize(this.props.source.uri, (w, h) => {
       this.setState({width: w, height: h});
     });
   }


### PR DESCRIPTION
I found out that's because of mipmapping in iOS.
If you set default width, height = 1, it will use this version even after changing width, height.
Reset it to 0, and also set as `async` while checking image size, it speeds up loading speed.