### PR TITLE
Loosen View style restrictions

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -135,7 +135,7 @@ HtmlView.propTypes = {
   renderNode: PropTypes.func,
   RootComponent: PropTypes.func,
   rootComponentProps: PropTypes.object,
-  style: View.propTypes.style,
+  style: PropTypes.object,
   stylesheet: PropTypes.object,
   TextComponent: PropTypes.func,
   textComponentProps: PropTypes.object,


### PR DESCRIPTION
Adding `Text`-specific style opts cause a warning: invalid props.style because the style prop is set to expect `View`-specific style opts. This patch loosens the requirement to a general object, matching the `stylesheet` propType.

Not sure if you want to set this in general, but in my case I wanted to use `textAlign: 'center'` on a block level element with inline children, ie.

```html
<p>A paragraph with an <em>italic bit somewhere</em>.</p>
```

and couldn't find any combination of props that would allow this and maintain child styles - except to set the style directly on the `HTMLView` itself, with `RootComponent={Text}` set, eg.

```js
<HTMLView
  RootComponent={Text}
  style={{
    color: '#231F20',
    fontSize: 14,
    lineHeight: 14 * 1.3,
    paddingLeft: 20,
    paddingRight: 20,
    textAlign: 'center',
  }}
  value={this.data.content.body}
/>
```
 This worked fine, but threw a warning because the `HTMLView` is expecting `View` style props.