### PR TITLE
Place the startHtmlRender in the InteractionManager.runAfterInteractions

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -50,14 +50,14 @@ class HtmlView extends PureComponent {
     this.mounted = true;
     InteractionManager.runAfterInteractions(() => {
       this.startHtmlRender(this.props.value);
-    })
+    });
   }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.value !== nextProps.value || this.props.stylesheet !== nextProps.stylesheet) {
       InteractionManager.runAfterInteractions(() => {
         this.startHtmlRender(nextProps.value, nextProps.stylesheet);
-      })
+      });
     }
   }
 

--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import htmlToElement from './htmlToElement';
-import {Linking, Platform, StyleSheet, View, ViewPropTypes} from 'react-native';
+import {Linking, Platform, StyleSheet, View, ViewPropTypes, InteractionManager} from 'react-native';
 
 const boldStyle = {fontWeight: '500'};
 const italicStyle = {fontStyle: 'italic'};
@@ -48,12 +48,16 @@ class HtmlView extends PureComponent {
 
   componentDidMount() {
     this.mounted = true;
-    this.startHtmlRender(this.props.value);
+    InteractionManager.runAfterInteractions(() => {
+      this.startHtmlRender(this.props.value);
+    })
   }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.value !== nextProps.value || this.props.stylesheet !== nextProps.stylesheet) {
-      this.startHtmlRender(nextProps.value, nextProps.stylesheet);
+      InteractionManager.runAfterInteractions(() => {
+        this.startHtmlRender(nextProps.value, nextProps.stylesheet);
+      })
     }
   }
 


### PR DESCRIPTION
I think this is a little optimization that avoids some animated delays that occur when navigating the switch