### PR TITLE
Update htmlparser2-without-node-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   },
   "dependencies": {
     "entities": "^1.1.1",
-    "htmlparser2-without-node-native": "^3.9.0"
+    "htmlparser2-without-node-native": "^3.9.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,7 +1946,7 @@ fbjs@0.8.12:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -2288,9 +2288,9 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-htmlparser2-without-node-native@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2-without-node-native/-/htmlparser2-without-node-native-3.9.0.tgz#7594357386e43be3d9ec4264df9d7ec60f81a7df"
+htmlparser2-without-node-native@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2-without-node-native/-/htmlparser2-without-node-native-3.9.2.tgz#b3ed050d877d0ff3465969e339877b7f9f6631f6"
   dependencies:
     domelementtype "^1.3.0"
     domhandler "^2.3.0"
@@ -3641,13 +3641,6 @@ raw-body@~2.1.2:
     bytes "2.4.0"
     iconv-lite "0.4.13"
     unpipe "1.0.0"
-
-react-addons-test-utils@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
 
 react-clone-referenced-element@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Update `htmlparser2-without-node-native` to prevent issues with  `inline-requires` babel plugin: https://github.com/oyyd/htmlparser2-without-node-native/pull/1