### PR TITLE
Fix line breaks for li

### DIFF
--- a/__tests__/HTMLView-test.js
+++ b/__tests__/HTMLView-test.js
@@ -134,11 +134,7 @@ describe('<HTMLView/>', () => {
 
     function renderNode(node, index) {
       if (node.name == 'thing') {
-        return (
-          <Text key={index}>
-            {node.attribs.b}
-          </Text>
-        );
+        return <Text key={index}>{node.attribs.b}</Text>;
       }
     }
 

--- a/__tests__/HTMLView-test.js
+++ b/__tests__/HTMLView-test.js
@@ -134,7 +134,11 @@ describe('<HTMLView/>', () => {
 
     function renderNode(node, index) {
       if (node.name == 'thing') {
-        return <Text key={index}>{node.attribs.b}</Text>;
+        return (
+          <Text key={index}>
+            {node.attribs.b}
+          </Text>
+        );
       }
     }
 

--- a/__tests__/HTMLView-test.js
+++ b/__tests__/HTMLView-test.js
@@ -125,6 +125,16 @@ describe('<HTMLView/>', () => {
     ).toMatchSnapshot();
   });
 
+  it('should not render extra linebreaks in list items if configured not to', () => {
+    const htmlContent = '<ul><li> a </li><li> b </li></ul>';
+
+    expect(
+      renderer
+        .create(<HTMLView value={htmlContent} addLineBreaks={false} />)
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+
   it('can use a custom renderer', () => {
     const htmlContent = `
       <div>

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -826,8 +826,6 @@ exports[`<HTMLView/> should render ol numbers 1`] = `
       >
          b 
       </Text>
-      
-      
     </Text>
   </Text>
 </View>
@@ -1274,8 +1272,6 @@ exports[`<HTMLView/> should render ul bullets 1`] = `
       >
          b 
       </Text>
-      
-      
     </Text>
   </Text>
 </View>

--- a/__tests__/__snapshots__/HTMLView-test.js.snap
+++ b/__tests__/__snapshots__/HTMLView-test.js.snap
@@ -557,6 +557,99 @@ exports[`<HTMLView/> should not render extra linebreaks if configured not to 1`]
 </View>
 `;
 
+exports[`<HTMLView/> should not render extra linebreaks in list items if configured not to 1`] = `
+<View
+  style={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    disabled={false}
+    ellipsizeMode="tail"
+    onLongPress={null}
+    onPress={null}
+    style={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      onLongPress={null}
+      onPress={null}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Object {},
+          ]
+        }
+      >
+        • 
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Object {},
+          ]
+        }
+      >
+         a 
+      </Text>
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      onLongPress={null}
+      onPress={null}
+      style={null}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Object {},
+          ]
+        }
+      >
+        • 
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            null,
+            Object {},
+          ]
+        }
+      >
+         b 
+      </Text>
+    </Text>
+  </Text>
+</View>
+`;
+
 exports[`<HTMLView/> should render an <Image /> with set width/height 1`] = `
 <View
   style={undefined}

--- a/example/Example.js
+++ b/example/Example.js
@@ -6,9 +6,7 @@ function renderNode(node, index) {
   if (node.name == 'iframe') {
     return (
       <View key={index} style={{width: 200, height: 200}}>
-        <Text>
-          {node.attribs.src}
-        </Text>
+        <Text>{node.attribs.src}</Text>
       </View>
     );
   }

--- a/example/Example.js
+++ b/example/Example.js
@@ -6,7 +6,9 @@ function renderNode(node, index) {
   if (node.name == 'iframe') {
     return (
       <View key={index} style={{width: 200, height: 200}}>
-        <Text>{node.attribs.src}</Text>
+        <Text>
+          {node.attribs.src}
+        </Text>
       </View>
     );
   }

--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -137,7 +137,9 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
               {opts.bullet}
             </TextComponent>);
           }
-          linebreakAfter = opts.lineBreak;
+          if (opts.addLineBreaks && index < list.length - 1) {
+            linebreakAfter = opts.lineBreak;
+          }
         }
 
         const {NodeComponent, styles} = opts;


### PR DESCRIPTION
Fix line breaks for `<li>` elements:
- add line break only if addLineBreaks is true 
- add line breaks only between `<li>` elements (do not set a line break for the last `<li>`, similar as it is done with paragraphs)