### PR TITLE
Fix error on react native version 0.56 caused by defaultProps for RootComponent

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -154,7 +154,7 @@ HtmlView.defaultProps = {
   onLinkPress: url => Linking.openURL(url),
   onLinkLongPress: null,
   onError: console.error.bind(console),
-  RootComponent: View,
+  RootComponent: element => <View {...element} />, // eslint-disable-line react/display-name
 };
 
 export default HtmlView;


### PR DESCRIPTION
> Failed prop type: Invalid prop `RootComponent` of type `object` supplied to `HtmlView`, expected `function`

Fix above error by change defaultProps for RootComponent to render function