### PR TITLE
Fix error thrown when invalid html for lists

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -128,7 +128,9 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
           const defaultStyle = opts.textComponentProps ? opts.textComponentProps.style : null;
           const customStyle = inheritedStyle(parent);
 
-          if (parent.name === 'ol') {
+          if(!parent){
+            listItemPrefix = null;
+          } else if (parent.name === 'ol') {
             listItemPrefix = (<TextComponent style={[defaultStyle, customStyle]}>
               {`${orderedListCounter++}. `}
             </TextComponent>);


### PR DESCRIPTION
Currently if invalid markup for Lists/List Items is passed to the component, an uncaught error is thrown and it doesn't die gracefully.  The code assumes that all `<li>` nodes have a parent `<ul>`. With this assumption, the code attempts to check the parent's name: `parent.name`. If invalid markup is passed, parent is undefined, so the uncaught error reads "TypeError: Cannot read property 'name' of undefined" 

Invalid markup that will make it crash:
`<li>
    <ul>
        <li>Fine & Visual Art</li>
        <li>Vocal Music</li>
        <li>Instrumental</li>
    </ul>
    `

Since we cannot assume the correct markup in this scenario, this fix will ignore `<li>` without a parent node and won't render anything.

P.S. This is my first react-native commit, so please let me know if I can improve upon anything. Thanks!
