### PR TITLE
Remove PropTypes

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,7 +1,6 @@
 import React, {PureComponent} from 'react';
-import PropTypes from 'prop-types';
 import htmlToElement from './htmlToElement';
-import {Linking, Platform, StyleSheet, View, ViewPropTypes} from 'react-native';
+import {Linking, Platform, StyleSheet, View} from 'react-native';
 
 const boldStyle = {fontWeight: 'bold'};
 const italicStyle = {fontStyle: 'italic'};
@@ -132,26 +131,6 @@ class HtmlView extends PureComponent {
     );
   }
 }
-
-HtmlView.propTypes = {
-  addLineBreaks: PropTypes.bool,
-  bullet: PropTypes.string,
-  lineBreak: PropTypes.string,
-  NodeComponent: PropTypes.func,
-  nodeComponentProps: PropTypes.object,
-  onError: PropTypes.func,
-  onLinkPress: PropTypes.func,
-  onLinkLongPress: PropTypes.func,
-  paragraphBreak: PropTypes.string,
-  renderNode: PropTypes.func,
-  RootComponent: PropTypes.func,
-  rootComponentProps: PropTypes.object,
-  style: ViewPropTypes.style,
-  stylesheet: PropTypes.object,
-  TextComponent: PropTypes.func,
-  textComponentProps: PropTypes.object,
-  value: PropTypes.string,
-};
 
 HtmlView.defaultProps = {
   addLineBreaks: true,


### PR DESCRIPTION
React native recently completely removed ViewPropTypes. It has been deprecated for a while. This removes prop types from the component.

See https://github.com/facebook/react-native/commit/10199b158138b8645550b5579df87e654213fe42