### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prettier": "^1.18.2",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
-    "react-test-renderer": "16.5.0"
+    "react-test-renderer": "16.5.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
ViewPropTypes has been removed completely in React Native `v0.70.4`