### PR TITLE
Fix proptypes

### DIFF
--- a/HTMLView.js
+++ b/HTMLView.js
@@ -1,7 +1,9 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import htmlToElement from './htmlToElement';
-import {Linking, Platform, StyleSheet, View, ViewPropTypes} from 'react-native';
+import {Linking, Platform, StyleSheet, View} from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
+
 
 const boldStyle = {fontWeight: 'bold'};
 const italicStyle = {fontStyle: 'italic'};


### PR DESCRIPTION
import {Linking, Platform, StyleSheet, View} from 'react-native';
import { ViewPropTypes } from 'deprecated-react-native-prop-types';